### PR TITLE
feat: allow the hash param to be a string or a boolean.

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -50,10 +50,10 @@
 
 ### `hash`
 
-- **Type:** `Boolean`
+- **Type:** `Boolean`, `String`
 - **Default:** `false`
 - **Synced**
-- **Description:** If true, the map's position (zoom, center latitude, center longitude, bearing, and pitch) will be synced with the hash fragment of the page's URL
+- **Description:** If true, the map's position (zoom, center latitude, center longitude, bearing, and pitch) will be synced with the hash fragment of the page's URL. If it's a string, it will be the name of the param in a parameter-styled hash.
 - **See:** `options.hash` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
 
 ### `interactive`

--- a/src/components/map/options.js
+++ b/src/components/map/options.js
@@ -22,7 +22,7 @@ export default {
     required: true,
   },
   hash: {
-    type: Boolean,
+    type: [Boolean, String],
     default: false,
   },
   interactive: {


### PR DESCRIPTION
Since the [version 1.5.0](https://github.com/mapbox/mapbox-gl-js/releases/tag/v1.5.0), vue-mapbox allow the hash param to be a boolean or a string.

Same code as https://github.com/soal/vue-mapbox/pull/155